### PR TITLE
Updated Dutch translation

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -1,588 +1,514 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the de.wagnermartin.Plattenalbum package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: de.wagnermartin.Plattenalbum\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-26 20:43+0100\n"
-"PO-Revision-Date: 2023-01-15 18:17+0100\n"
+"POT-Creation-Date: 2024-03-07 00:16+0100\n"
+"PO-Revision-Date: 2024-03-10 01:02+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.2\n"
 
-#: src/mpdevil.py:502
+#: src/plattenalbum.py:506
 #, python-brace-format
 msgid "{days} day"
 msgid_plural "{days} days"
 msgstr[0] "{days} dag"
 msgstr[1] "{days} dagen"
 
-#: src/mpdevil.py:539
+#: src/plattenalbum.py:543
 #, python-brace-format
 msgid "{channels} channel"
 msgid_plural "{channels} channels"
 msgstr[0] "{channels} kanaal"
 msgstr[1] "{channels} kanalen"
 
-#: src/mpdevil.py:1005
-msgid "(restart required)"
-msgstr "(herstart vereist)"
+#: src/plattenalbum.py:966
+msgid "View"
+msgstr "Weergave"
 
-#: src/mpdevil.py:1051
-msgid "Use Client-side decoration"
-msgstr "Gebruik vensterdecoratie van mpdevil"
+#: src/plattenalbum.py:968
+msgid "Show _stop button"
+msgstr "Toon _stop knop"
 
-#: src/mpdevil.py:1052
-msgid "Show stop button"
-msgstr "Toon stopknop"
+#: src/plattenalbum.py:969
+msgid "Show audio _format"
+msgstr "Toon audio_formaat"
 
-#: src/mpdevil.py:1053
-msgid "Show audio format"
-msgstr "Toon audioformaat"
+#: src/plattenalbum.py:978
+msgid "Behavior"
+msgstr "Gedrag"
 
-#: src/mpdevil.py:1054
-msgid "Show lyrics button"
-msgstr "Toon songtekstknop"
+#: src/plattenalbum.py:980
+msgid "Support “_MPRIS”"
+msgstr "Ondersteuning voor “_MPRIS”"
 
-#: src/mpdevil.py:1055
-msgid "Place playlist at the side"
-msgstr "Plaats afspeellijst aan de zijkant"
+#: src/plattenalbum.py:980
+msgid "restart required"
+msgstr "opnieuw opstarten vereist"
 
-#: src/mpdevil.py:1061
-msgid "Album view cover size"
-msgstr "Hoesgrootte in albumlijst"
+#: src/plattenalbum.py:981
+msgid "Sort _albums by year"
+msgstr "Sorteer albums op _jaar"
 
-#: src/mpdevil.py:1062
-msgid "Action bar icon size"
-msgstr "Grootte iconen werkbalk"
+#: src/plattenalbum.py:982
+msgid "Send _notification on title change"
+msgstr "Verstuur _melding na titelwisseling"
 
-#: src/mpdevil.py:1072
-msgid "Support “MPRIS”"
-msgstr "Ondersteun „MPRIS”"
+#: src/plattenalbum.py:983
+msgid "_Rewind via previous button"
+msgstr "_Terugspoelen via vorige knop"
 
-#: src/mpdevil.py:1073
-msgid "Sort albums by year"
-msgstr "Sorteer albums op jaar"
+#: src/plattenalbum.py:984
+msgid "Stop _playback on quit"
+msgstr "Stop met _afspelen na afsluiten"
 
-#: src/mpdevil.py:1074
-msgid "Send notification on title change"
-msgstr "Verstuur een melding bij titelwisseling"
+#: src/plattenalbum.py:993
+msgid "Socket path"
+msgstr "Socket pad"
 
-#: src/mpdevil.py:1075
-msgid "Rewind via previous button"
-msgstr "Terugspoelen met „vorige” knop"
+#: src/plattenalbum.py:994
+msgid "Pick a File"
+msgstr "Kies een Bestand"
 
-#: src/mpdevil.py:1076
-msgid "Stop playback on quit"
-msgstr "Stop afspelen bij afsluiten"
+#: src/plattenalbum.py:1013
+msgid "Music library"
+msgstr "Muziekbibliotheek"
 
-#: src/mpdevil.py:1103
-msgid "Choose directory"
-msgstr "Kies een map"
+#: src/plattenalbum.py:1014
+msgid "Select a Folder"
+msgstr "Kies een Map"
 
-#. labels and entries
-#: src/mpdevil.py:1118
-msgid "Connect via Unix domain socket"
-msgstr "Verbinden via Unix domain socket"
+#: src/plattenalbum.py:1033
+msgid "Connection"
+msgstr "Verbinding"
 
-#: src/mpdevil.py:1137
+#: src/plattenalbum.py:1035
+msgid "Connect via _Unix domain socket"
+msgstr "Verbinden via een _Unix domein socket"
+
+#: src/plattenalbum.py:1045
+msgid "Port"
+msgstr "Port"
+
+#: src/plattenalbum.py:1050
+msgid "Hostname"
+msgstr "Hostnaam"
+
+#: src/plattenalbum.py:1060
+msgid "Regex"
+msgstr "Reguliere expressie"
+
+#: src/plattenalbum.py:1062
 msgid ""
 "The first image in the same directory as the song file matching this regex "
 "will be displayed. %AlbumArtist% and %Album% will be replaced by the "
 "corresponding tags of the song."
 msgstr ""
-"De eerste afbeelding in dezelfde map als het muziekbestand die overeenkomt "
-"met deze regex wordt getoond. %AlbumArtist% en %Album% worden vervangen door "
-"de bijbehorende tags van het muziekbestand."
+"De eerste afbeelding in dezelfde map als het muziekbestand die met deze "
+"reguliere expressie overeenkomt zal worden getoond. %AlbumArtist% en "
+"%Album% zullen vervangen worden door de tags van het corresponderende "
+"nummer."
 
-#: src/mpdevil.py:1142
-msgid "Socket:"
-msgstr "Socket:"
-
-#: src/mpdevil.py:1144
-msgid "Host:"
-msgstr "Host:"
-
-#: src/mpdevil.py:1146
-msgid "Password:"
-msgstr "Wachtwoord:"
-
-#: src/mpdevil.py:1147
-msgid "Music lib:"
-msgstr "Muziekmap:"
-
-#: src/mpdevil.py:1149
-msgid "Cover regex:"
-msgstr "Regex albumhoes:"
+#: src/plattenalbum.py:1069
+msgid "Password"
+msgstr "Wachtwoord"
 
 #. connect button
-#: src/mpdevil.py:1152 src/mpdevil.py:3155
-msgid "Connect"
-msgstr "Verbinden"
+#: src/plattenalbum.py:1074 data/ShortcutsWindow.ui:37
+msgid "Reconnect"
+msgstr "Opnieuw Verbinden"
 
-#: src/mpdevil.py:1175 src/mpdevil.py:1177 src/mpdevil.py:3156
-#: src/mpdevil.py:3245
-msgid "Preferences"
-msgstr "Voorkeuren"
+#: src/plattenalbum.py:1093 data/ShortcutsWindow.ui:49
+msgid "Server Statistics"
+msgstr "Server Statistieken"
 
-#: src/mpdevil.py:1189 src/mpdevil.py:1199
-msgid "View"
-msgstr "Beeld"
+#: src/plattenalbum.py:1102
+msgid "Protocol"
+msgstr "Protocol"
 
-#: src/mpdevil.py:1190 src/mpdevil.py:1200
-msgid "Behavior"
-msgstr "Gedrag"
+#: src/plattenalbum.py:1103
+msgid "Uptime"
+msgstr "Uptime"
 
-#: src/mpdevil.py:1191 src/mpdevil.py:1201
-msgid "Connection"
-msgstr "Verbinding"
+#: src/plattenalbum.py:1104
+msgid "Playtime"
+msgstr "Afspeeltijd"
 
-#: src/mpdevil.py:1218
-msgid "Stats"
-msgstr "Statistieken"
+#: src/plattenalbum.py:1105
+msgid "Artists"
+msgstr "Artiesten"
 
-#: src/mpdevil.py:1227
-msgid "<b>Protocol:</b>"
-msgstr "<b>Protocol:</b>"
+#: src/plattenalbum.py:1106
+msgid "Albums"
+msgstr "Albums"
 
-#: src/mpdevil.py:1228
-msgid "<b>Uptime:</b>"
-msgstr "<b>Uptime:</b>"
+#: src/plattenalbum.py:1107
+msgid "Songs"
+msgstr "Nummer"
 
-#: src/mpdevil.py:1229
-msgid "<b>Playtime:</b>"
-msgstr "<b>Afspeeltijd:</b>"
+#: src/plattenalbum.py:1108
+msgid "Total Playtime"
+msgstr "Totale Afspeeltijd"
 
-#: src/mpdevil.py:1230
-msgid "<b>Artists:</b>"
-msgstr "<b>Artiesten:</b>"
+#: src/plattenalbum.py:1109
+msgid "Database Update"
+msgstr "Database Update"
 
-#: src/mpdevil.py:1231
-msgid "<b>Albums:</b>"
-msgstr "<b>Albums:</b>"
+#: src/plattenalbum.py:1226 src/plattenalbum.py:1929
+msgid "Context menu"
+msgstr "Context menu"
 
-#: src/mpdevil.py:1232
-msgid "<b>Songs:</b>"
-msgstr "<b>Titels:</b>"
+#: src/plattenalbum.py:1248
+msgid "_Append"
+msgstr "_toevoegen"
 
-#: src/mpdevil.py:1233
-msgid "<b>Total Playtime:</b>"
-msgstr "<b>Totale speelduur:</b>"
+#: src/plattenalbum.py:1249
+msgid "As _Next"
+msgstr "Als _Volgende"
 
-#: src/mpdevil.py:1234
-msgid "<b>Database Update:</b>"
-msgstr "<b>Database bijgewerkt:</b>"
+#: src/plattenalbum.py:1250
+msgid "_Play"
+msgstr "_Afspelen"
 
-#: src/mpdevil.py:1301 src/mpdevil.py:2175
-msgid "No"
-msgstr "Nr"
+#: src/plattenalbum.py:1252 src/plattenalbum.py:1947
+msgid "_Show"
+msgstr "_Toon in Map"
 
-#: src/mpdevil.py:1302 src/mpdevil.py:2176
-msgid "Title"
-msgstr "Titel"
+#. status page
+#: src/plattenalbum.py:1436
+msgid "No Results Found"
+msgstr "Geen Resultaten Gevonden"
 
-#: src/mpdevil.py:1303 src/mpdevil.py:2177
-msgid "Length"
-msgstr "Lengte"
+#: src/plattenalbum.py:1436
+msgid "Try a different search"
+msgstr "Probeer een andere zoekopdracht"
 
-#: src/mpdevil.py:1317 src/mpdevil.py:1339
+#: src/plattenalbum.py:1631 src/plattenalbum.py:1775
+#, python-brace-format
+msgid "Album cover of {album}"
+msgstr "Albumhoes van {album}"
+
+#: src/plattenalbum.py:1634 src/plattenalbum.py:1778
+msgid "Album cover of an unknown album"
+msgstr "Albumhoes van een onbekend album"
+
+#: src/plattenalbum.py:1699
+#, python-brace-format
+msgid "Albums of {artist}"
+msgstr "Albums van {artist}"
+
+#: src/plattenalbum.py:1733
 msgid "Append"
 msgstr "Toevoegen"
 
-#: src/mpdevil.py:1318 src/mpdevil.py:1340 src/mpdevil.py:2668
-#: src/mpdevil.py:2701
+#. widgets
+#: src/plattenalbum.py:1734 src/plattenalbum.py:2324 src/plattenalbum.py:2345
 msgid "Play"
 msgstr "Afspelen"
 
-#: src/mpdevil.py:1341 src/mpdevil.py:2197
-msgid "Show"
-msgstr "Tonen"
-
-#: src/mpdevil.py:1432
-#, python-brace-format
-msgid "{hits} hit"
-msgid_plural "{hits} hits"
-msgstr[0] "{hits} hit"
-msgstr[1] "{hits} treffers"
-
-#: src/mpdevil.py:1517
-msgid "all tags"
-msgstr "alle tags"
-
-#: src/mpdevil.py:1652
-msgid "all genres"
-msgstr "alle genres"
-
-#: src/mpdevil.py:1675
-msgid "all artists"
-msgstr "alle artiesten"
-
-#: src/mpdevil.py:2041
+#: src/plattenalbum.py:1785
 #, python-brace-format
 msgid "{number} song ({duration})"
 msgid_plural "{number} songs ({duration})"
 msgstr[0] "{number} nummer ({duration})"
 msgstr[1] "{number} nummers ({duration})"
 
-#: src/mpdevil.py:2196
-msgid "Remove"
-msgstr "Verwijderen"
+#. status page
+#: src/plattenalbum.py:1850
+msgid "Collection is Empty"
+msgstr "Collectie is Leeg"
 
-#: src/mpdevil.py:2199
-msgid "Enqueue Album"
-msgstr "Album invoegen"
+#: src/plattenalbum.py:1946
+msgid "_Remove"
+msgstr "_Verwijderen"
 
-#: src/mpdevil.py:2200
-msgid "Tidy"
-msgstr "Opruimen"
+#: src/plattenalbum.py:1949
+msgid "_Enqueue Album"
+msgstr "Album aan wachtrij toevoegen"
 
-#: src/mpdevil.py:2202
-msgid "Clear"
-msgstr "Wissen"
+#: src/plattenalbum.py:1950
+msgid "_Tidy"
+msgstr "_Opschonen"
 
-#: src/mpdevil.py:2375
-msgid "Scroll to current song"
-msgstr "Naar de huidige titel scrollen"
+#: src/plattenalbum.py:1952
+msgid "_Clear"
+msgstr "_Leegmaken"
 
-#: src/mpdevil.py:2493
+#. widgets
+#. TODO scroll to song
+#: src/plattenalbum.py:2126
+msgid "Playlist is Empty"
+msgstr "Afspeellijst is Leeg"
+
+#. status pages
+#: src/plattenalbum.py:2195
+msgid "No Lyrics Found"
+msgstr "Geen Lyrics Gevonden"
+
+#: src/plattenalbum.py:2198
+msgid "Connection Error"
+msgstr "Verbindingsfout"
+
+#: src/plattenalbum.py:2198
+msgid "Check your network connection"
+msgstr "Controleer je netwerk verbinding"
+
+#: src/plattenalbum.py:2251
+#, python-brace-format
+msgid "Lyrics of {song}"
+msgstr "Lyrics van {song}"
+
+#: src/plattenalbum.py:2252
 msgid "searching…"
-msgstr "bezig met zoeken…"
+msgstr "zoeken…"
 
-#: src/mpdevil.py:2498
-msgid "connection error"
-msgstr "verbindingsfout"
+#: src/plattenalbum.py:2259 src/plattenalbum.py:2264
+msgid "Lyrics view"
+msgstr "Lyrics weergave"
 
-#: src/mpdevil.py:2500
-msgid "lyrics not found"
-msgstr "geen songtekst gevonden"
+#: src/plattenalbum.py:2269
+msgid "Current album cover"
+msgstr "Huidige albumcover"
 
-#: src/mpdevil.py:2612
-msgid "Lyrics"
-msgstr "Songtekst"
-
-#: src/mpdevil.py:2670 data/ShortcutsWindow.ui:105
+#: src/plattenalbum.py:2325 data/ShortcutsWindow.ui:89
 msgid "Stop"
-msgstr "Stoppen"
+msgstr "Stop"
 
-#: src/mpdevil.py:2674 data/ShortcutsWindow.ui:126
-msgid "Previous title"
-msgstr "Vorige titel"
+#: src/plattenalbum.py:2327 data/ShortcutsWindow.ui:101
+msgid "Previous"
+msgstr "Vorige"
 
-#: src/mpdevil.py:2677 data/ShortcutsWindow.ui:119
-msgid "Next title"
-msgstr "Volgende titel"
+#: src/plattenalbum.py:2328 data/ShortcutsWindow.ui:95
+msgid "Next"
+msgstr "Volgende"
 
-#: src/mpdevil.py:2698
+#: src/plattenalbum.py:2342
 msgid "Pause"
 msgstr "Pauzeren"
 
-#: src/mpdevil.py:2901
-msgid "Repeat mode"
-msgstr "Herhaalmodus"
+#: src/plattenalbum.py:2361
+msgid "Progress bar"
+msgstr "Voortgangsbalk"
 
-#: src/mpdevil.py:2902
-msgid "Random mode"
-msgstr "Willekeurige modus"
+#: src/plattenalbum.py:2552
+msgid "Playback Menu"
+msgstr "Afspeelmenu"
 
-#: src/mpdevil.py:2903
-msgid "Single mode"
-msgstr "Enkele modus"
+#: src/plattenalbum.py:2556
+msgid "_Repeat Mode"
+msgstr "_Herhaalmodus"
 
-#: src/mpdevil.py:2904
-msgid "Consume mode"
-msgstr "Verbruiksmodus"
+#: src/plattenalbum.py:2557
+msgid "R_andom Mode"
+msgstr "_Willekeurige modus"
 
-#: src/mpdevil.py:3125
-msgid "Updating Database…"
-msgstr "Database bijwerken…"
+#: src/plattenalbum.py:2558
+msgid "_Single Mode"
+msgstr "_Enkele modus"
 
-#: src/mpdevil.py:3173
-#, python-brace-format
-msgid "Connection to “{socket}” failed"
-msgstr "Verbinding met „{socket}” mislukt"
+#: src/plattenalbum.py:2559
+msgid "_Pause After Song"
+msgstr "_Pauzeren Na Nummer"
 
-#: src/mpdevil.py:3175
-#, python-brace-format
-msgid "Connection to “{host}:{port}” failed"
-msgstr "Verbinding met „{host}:{port}” mislukt"
+#: src/plattenalbum.py:2560
+msgid "_Consume Mode"
+msgstr "_Consumeer Modus"
 
-#: src/mpdevil.py:3229
+#: src/plattenalbum.py:2716
+msgid "Not connected to “Music Player Daemon”"
+msgstr "Niet verbonden met “Music Player Daemon”"
+
+#: src/plattenalbum.py:2717 data/ShortcutsWindow.ui:19
+msgid "Preferences"
+msgstr "Voorkeuren"
+
+#: src/plattenalbum.py:2718
+msgid "Database is being updated"
+msgstr "Database wordt geüpdate"
+
+#: src/plattenalbum.py:2719
+msgid "Database updated"
+msgstr "Database geüpdate"
+
+#: src/plattenalbum.py:2731
+msgid "_Preferences"
+msgstr "_Voorkeuren"
+
+#: src/plattenalbum.py:2732
+msgid "_Keyboard Shortcuts"
+msgstr "_Sneltoetsen"
+
+#: src/plattenalbum.py:2733
+msgid "_Help"
+msgstr "_Help"
+
+#: src/plattenalbum.py:2734
+msgid "_About Plattenalbum"
+msgstr "_Over Plattenalbum"
+
+#: src/plattenalbum.py:2736
+msgid "_Reconnect"
+msgstr "Op_nieuw verbinden"
+
+#: src/plattenalbum.py:2737
+msgid "_Update Database"
+msgstr "_Update database"
+
+#: src/plattenalbum.py:2738
+msgid "_Server Statistics"
+msgstr "_Server Statistieken"
+
+#: src/plattenalbum.py:2740
+msgid "_Lyrics"
+msgstr "_Lyrics"
+
+#. menu button / popover
+#: src/plattenalbum.py:2745 data/ShortcutsWindow.ui:31
+msgid "Main Menu"
+msgstr "Hoofdmenu"
+
+#. search
+#: src/plattenalbum.py:2748
 msgid "Search"
 msgstr "Zoeken"
 
-#: src/mpdevil.py:3232
-msgid "Back"
-msgstr "Terug"
+#: src/plattenalbum.py:2749 src/plattenalbum.py:2750
+msgid "Search collection"
+msgstr "Zoek in collectie"
 
-#: src/mpdevil.py:3246
-msgid "Keyboard Shortcuts"
-msgstr "Sneltoetsen"
-
-#: src/mpdevil.py:3247
-msgid "Help"
-msgstr "Hulp"
-
-#: src/mpdevil.py:3248
-msgid "About mpdevil"
-msgstr "Over mpdevil"
-
-#: src/mpdevil.py:3250
-msgid "Update Database"
-msgstr "Database bijwerken"
-
-#: src/mpdevil.py:3251
-msgid "Server Stats"
-msgstr "Serverstatistieken"
-
-#: src/mpdevil.py:3253
-msgid "Mini Player"
-msgstr "Minispeler"
-
-#: src/mpdevil.py:3254
-msgid "Genre Filter"
-msgstr "Genrefilter"
-
-#: src/mpdevil.py:3263
-msgid "Menu"
-msgstr "Menu"
-
-#: src/mpdevil.py:3437 src/mpdevil.py:3439
+#: src/plattenalbum.py:2933
 msgid "connecting…"
-msgstr "verbinding maken…"
+msgstr "verbinden…"
 
-#: src/mpdevil.py:3477
+#: src/plattenalbum.py:2959
 msgid "Debug mode"
-msgstr "Debugmodus"
+msgstr "Debug modus"
 
-#: data/org.mpdevil.mpdevil.desktop.in:3
-msgid "mpdevil"
-msgstr "mpdevil"
+#: data/de.wagnermartin.Plattenalbum.appdata.xml.in:7
+#: data/de.wagnermartin.Plattenalbum.desktop.in:3
+msgid "Plattenalbum"
+msgstr "Plattenalbum"
 
-#: data/org.mpdevil.mpdevil.desktop.in:4
-msgid "MPD Client"
-msgstr "MPD Client"
+#: data/de.wagnermartin.Plattenalbum.appdata.xml.in:8
+#: data/de.wagnermartin.Plattenalbum.desktop.in:5
+msgid "Browse music with MPD"
+msgstr "Blader door muziek met MPD"
 
-#: data/org.mpdevil.mpdevil.desktop.in:5 data/AboutDialog.ui:7
-msgid "A simple music browser for MPD"
-msgstr "Een simpele muziekspeler voor MPD"
+#: data/de.wagnermartin.Plattenalbum.appdata.xml.in:10
+msgid "A client for the Music Player Daemon (MPD)."
+msgstr "Een client voor Music Player Daemon (MPD)."
 
-#: data/ShortcutsWindow.ui:12
+#: data/de.wagnermartin.Plattenalbum.appdata.xml.in:11
+msgid ""
+"Browse your collection while viewing large album covers. Play your music "
+"without managing playlists."
+msgstr ""
+"Blader door je verzameling terwijl je grote albumhoezen bekijkt. Speel je "
+"muziek af zonder afspeellijsten te beheren."
+
+#: data/de.wagnermartin.Plattenalbum.desktop.in:4
+msgid "Music Browser"
+msgstr "Muziekspeler"
+
+#: data/de.wagnermartin.Plattenalbum.desktop.in:12
+msgid "Music;Player;"
+msgstr "Muziek;Speler;"
+
+#: data/ShortcutsWindow.ui:10
 msgid "General"
 msgstr "Algemeen"
 
-#: data/ShortcutsWindow.ui:16
-msgid "Open online help"
-msgstr "Online hulp openen"
+#: data/ShortcutsWindow.ui:13
+msgid "Online Help"
+msgstr "Online Help"
 
-#: data/ShortcutsWindow.ui:23
-msgid "Open shortcuts window"
-msgstr "Venster met sneltoetsen openen"
+#: data/ShortcutsWindow.ui:25
+msgid "Shortcuts"
+msgstr "Sneltoetsen"
 
-#: data/ShortcutsWindow.ui:30
-msgid "Open menu"
-msgstr "Menu openen"
+#: data/ShortcutsWindow.ui:43
+msgid "Update Database"
+msgstr "Database updaten"
 
-#: data/ShortcutsWindow.ui:37
-msgid "Update database"
-msgstr "Database bijwerken"
-
-#: data/ShortcutsWindow.ui:44
-msgid "Clear playlist"
-msgstr "Afspeellijst legen"
-
-#: data/ShortcutsWindow.ui:51
+#: data/ShortcutsWindow.ui:55
 msgid "Quit"
-msgstr "Stoppen"
+msgstr "Afsluiten"
 
-#: data/ShortcutsWindow.ui:60
+#: data/ShortcutsWindow.ui:63
 msgid "Window"
 msgstr "Venster"
 
-#: data/ShortcutsWindow.ui:64
-msgid "Toggle mini player"
-msgstr "Omschakelen naar minispeler"
+#: data/ShortcutsWindow.ui:66
+msgid "Toggle Lyrics"
+msgstr "Lyrics aan-/uitzetten"
 
-#: data/ShortcutsWindow.ui:71
-msgid "Toggle genre filter"
-msgstr "Genrefilter aan/uitzetten"
+#: data/ShortcutsWindow.ui:72
+msgid "Toggle Search"
+msgstr "Zoeken aan-/uitzetten"
 
-#: data/ShortcutsWindow.ui:78
-msgid "Toggle lyrics"
-msgstr "Omschakelen naar songtekst"
-
-#: data/ShortcutsWindow.ui:85
-msgid "Toggle search"
-msgstr "Omschakelen naar zoeken"
-
-#: data/ShortcutsWindow.ui:94
+#: data/ShortcutsWindow.ui:80
 msgid "Playback"
 msgstr "Afspelen"
 
-#: data/ShortcutsWindow.ui:98
+#: data/ShortcutsWindow.ui:83
 msgid "Play/Pause"
 msgstr "Afspelen/Pauzeren"
 
-#: data/ShortcutsWindow.ui:112
-msgid "Stop after current title"
-msgstr "Stop na huidige titel"
+#: data/ShortcutsWindow.ui:107
+msgid "Seek Forward"
+msgstr "Vooruit Spoelen"
 
-#: data/ShortcutsWindow.ui:133
-msgid "Seek forward"
-msgstr "Vooruit spoelen"
+#: data/ShortcutsWindow.ui:113
+msgid "Seek Backward"
+msgstr "Achteruit Spoelen"
 
-#: data/ShortcutsWindow.ui:140
-msgid "Seek backward"
-msgstr "Achteruit spoelen"
+#: data/ShortcutsWindow.ui:121
+msgid "Playback Options"
+msgstr "Afspeel opties"
 
-#: data/ShortcutsWindow.ui:147
-msgid "Toggle repeat mode"
-msgstr "Omschakelen naar herhaalmodus"
+#: data/ShortcutsWindow.ui:124
+msgid "Toggle Repeat Mode"
+msgstr "Herhaalmodus aan-/uitzetten"
 
-#: data/ShortcutsWindow.ui:154
-msgid "Toggle random mode"
-msgstr "Omschakelen naar willekeurige modus"
+#: data/ShortcutsWindow.ui:130
+msgid "Toggle Random Mode"
+msgstr "Willekeurige modus aan-/uitzetten"
 
-#: data/ShortcutsWindow.ui:161
-msgid "Toggle single mode"
-msgstr "Omschakelen naar enkele modus"
+#: data/ShortcutsWindow.ui:136
+msgid "Toggle Single Mode"
+msgstr "Enkele modus aan-/uitzetten"
 
-#: data/ShortcutsWindow.ui:168
-msgid "Toggle consume mode"
-msgstr "Omschakelen naar verbruiksmodus"
+#: data/ShortcutsWindow.ui:142
+msgid "Pause After Song"
+msgstr "Pauzeer Na Nummer"
 
-#~ msgid "Play selected albums and titles immediately"
-#~ msgstr "Geselecteerde albums en titels direct afspelen"
+#: data/ShortcutsWindow.ui:148
+msgid "Toggle Consume Mode"
+msgstr "Consumeer modus aan-/uitzetten"
 
-#~ msgid "MPD-Tag"
-#~ msgstr "MPD-Tag"
+#: data/ShortcutsWindow.ui:156
+msgid "Playlist"
+msgstr "Afspeellijst"
 
-#~ msgid "Value"
-#~ msgstr "Waarde"
+#: data/ShortcutsWindow.ui:159
+msgid "Clear"
+msgstr "Wissen"
 
-#~ msgid "Add all titles to playlist"
-#~ msgstr "Voeg alle titels toe aan de afspeellijst"
+#: data/ShortcutsWindow.ui:165
+msgid "Tidy"
+msgstr "Opschonen"
 
-#~ msgid "Directly play all titles"
-#~ msgstr "Alle titels direct afspelen"
-
-#~ msgid "Back to current album"
-#~ msgstr "Terug naar huidige album"
-
-#~ msgid "Playlist"
-#~ msgstr "Afspeellijst"
-
-#, fuzzy
-#~ msgid "Show information"
-#~ msgstr "Toon informatie"
-
-#~ msgid "Search, Album Dialog and Album List"
-#~ msgstr "Zoeken, Albumdialoog en Albumlijst"
-
-#, fuzzy
-#~ msgid "Play immediately"
-#~ msgstr "Direct afspelen"
-
-#~ msgid "Profile 1"
-#~ msgstr "Profiel 1"
-
-#~ msgid "Profile 2"
-#~ msgstr "Profiel 2"
-
-#~ msgid "Profile 3"
-#~ msgstr "Profiel 3"
-
-#~ msgid "Profiles"
-#~ msgstr "Profielen"
-
-#~ msgid ""
-#~ "Append all titles after the currently playing track and clear the "
-#~ "playlist from all other songs"
-#~ msgstr ""
-#~ "Alle titels toevoegen na de nu spelende titel en alle overige titels uit "
-#~ "de afspeellijst verwijderen"
-
-#~ msgid "Save"
-#~ msgstr "Opslaan"
-
-#~ msgid "Delete"
-#~ msgstr "Verwijderen"
-
-#~ msgid "Playlists"
-#~ msgstr "Afspeellijsten"
-
-#~ msgid "Cycle through profiles"
-#~ msgstr "Profielen doorlopen"
-
-#~ msgid "Cycle through profiles in reversed order"
-#~ msgstr "Profielen doorlopen in omgekeerde volgorde"
-
-#~ msgid "Enqueue selected item"
-#~ msgstr "Geselecteerde item in wachtrij plaatsen"
-
-#~ msgid "Append selected item"
-#~ msgstr "Geselecteerde item toevoegen"
-
-#~ msgid "Middle-click"
-#~ msgstr "Middelklik"
-
-#~ msgid "Double-click"
-#~ msgstr "Dubbelklik"
-
-#~ msgid "Right-click"
-#~ msgstr "Rechtsklik"
-
-#~ msgid "Main cover size"
-#~ msgstr "Grootte albumhoes"
-
-#, python-brace-format
-#~ msgid "{number} song"
-#~ msgid_plural "{number} songs"
-#~ msgstr[0] "{number} nummer"
-#~ msgstr[1] "{number} nummers"
-
-#~ msgid "Open with…"
-#~ msgstr "Openen met…"
-
-#~ msgid "Choose the order of information to appear in the playlist:"
-#~ msgstr "Kies de volgorde van de informatie getoond in de afspeellijst:"
-
-#~ msgid "Disc"
-#~ msgstr "Disc"
-
-#~ msgid "Artist"
-#~ msgstr "Artiest"
-
-#~ msgid "Album"
-#~ msgstr "Album"
-
-#~ msgid "Year"
-#~ msgstr "Jaar"
-
-#~ msgid "Genre"
-#~ msgstr "Genre"
-
-#~ msgid "_Append"
-#~ msgstr "_Toevoegen"
-
-#~ msgid "_Play"
-#~ msgstr "_Afspelen"
-
-#~ msgid "_Enqueue"
-#~ msgstr "_In wachtrij plaatsen"
-
-#~ msgid "Use “Album Artist” tag"
-#~ msgstr "Gebruik tag „Album Artist”"
-
-#~ msgid "Filter by genre"
-#~ msgstr "Filter op genre"
-
-#~ msgid "Show lyrics"
-#~ msgstr "Toon songtekst"
+#: data/ShortcutsWindow.ui:171
+msgid "Enqueue Album"
+msgstr "Album aan wachtrij toevoegen"

--- a/po/nl.po
+++ b/po/nl.po
@@ -393,7 +393,7 @@ msgstr "verbinden…"
 
 #: src/plattenalbum.py:2959
 msgid "Debug mode"
-msgstr "Debug modus"
+msgstr "Debugmodus"
 
 #: data/de.wagnermartin.Plattenalbum.appdata.xml.in:7
 #: data/de.wagnermartin.Plattenalbum.desktop.in:3


### PR DESCRIPTION
Being a native Dutch speaker, I figured it might be helpful to translate any strings that have been added around the 2.0 release!

Couple of points/questions:
  * While technological jargon like "uptime" is probably translatable through some arcane combination of Dutch words, I think there's something to be said for going by the way people actually speak to each other. Hence, if an English expression is colloquial in Dutch, I've left it "untranslated". (in any case, Dutch borrows from English all the time, esp. computer-y words)
    * In line with this, I've left "Lyrics" as-is, instead of translating it to "songteksten" (as it was previously). I've never seen someone use "songteksten" in written or oral communication, and apperently, "Lyrics" [is recognized by ~90% of people](https://nl.wiktionary.org/wiki/lyrics) anyway. 
  * I did not translate the German "plattenalbum" to the similar "platenalbum" in Dutch, because I'm not sure if translating app names is appropiate.
  * I translated the "Show" right-click action as "Show in folder" - more so to raise the suggestion that this action should be probably get a more explicit name, anyway. Evince uses "Open Containing Folder" in a similar context, for example. 
