### PR TITLE
Fix capitalization and mnemonics errors in Dutch translation

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -63,7 +63,7 @@ msgstr "Sorteer albums op _jaar"
 
 #: src/plattenalbum.py:982
 msgid "Send _notification on title change"
-msgstr "Verstuur _melding na titelwisseling"
+msgstr "Verstuur _notificatie na titelwisseling"
 
 #: src/plattenalbum.py:983
 msgid "_Rewind via previous button"
@@ -171,7 +171,7 @@ msgstr "Context menu"
 
 #: src/plattenalbum.py:1248
 msgid "_Append"
-msgstr "_toevoegen"
+msgstr "_Toevoegen"
 
 #: src/plattenalbum.py:1249
 msgid "As _Next"
@@ -183,7 +183,7 @@ msgstr "_Afspelen"
 
 #: src/plattenalbum.py:1252 src/plattenalbum.py:1947
 msgid "_Show"
-msgstr "_Toon in Map"
+msgstr "Toon in _Map"
 
 #. status page
 #: src/plattenalbum.py:1436
@@ -235,7 +235,7 @@ msgstr "_Verwijderen"
 
 #: src/plattenalbum.py:1949
 msgid "_Enqueue Album"
-msgstr "Album aan wachtrij toevoegen"
+msgstr "Album aan _Wachtrij Toevoegen"
 
 #: src/plattenalbum.py:1950
 msgid "_Tidy"
@@ -347,7 +347,7 @@ msgstr "_Voorkeuren"
 
 #: src/plattenalbum.py:2732
 msgid "_Keyboard Shortcuts"
-msgstr "_Sneltoetsen"
+msgstr "Snel_toetsen"
 
 #: src/plattenalbum.py:2733
 msgid "_Help"


### PR DESCRIPTION
Fixes #101.

Sorry again! 