### PR TITLE
Fix gnome notifications

### DIFF
--- a/data/de.wagnermartin.Plattenalbum.desktop.in
+++ b/data/de.wagnermartin.Plattenalbum.desktop.in
@@ -9,3 +9,4 @@ Type=Application
 StartupNotify=true
 Categories=Audio;AudioVideo;Player;GTK;
 Keywords=Music;Player;
+X-GNOME-UsesNotifications=true


### PR DESCRIPTION
This PR fixes notifications on gnome. Previously they were not shown, because `X-GNOME-UsesNotifications=true` was missing from the .desktop file. [Relevant documentation](https://teams.pages.gitlab.gnome.org/Websites/developer.gnome.org/documentation/tutorials/notifications.html)