### PR TITLE
Update Flathub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Package Installation
 
 Flatpak:
 
-<a href='https://flathub.org/apps/details/de.wagnermartin.Plattenalbum'><img width='240' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
+<a href='https://flathub.org/apps/details/de.wagnermartin.Plattenalbum'><img width='240' alt='Download on Flathub' src='https://flathub.org/api/badge?svg&locale=en'/></a>
 
 Arch:
 - https://aur.archlinux.org/packages/plattenalbum


### PR DESCRIPTION
Flathub has updated to a more modern badge design, which is located at a different URL from the old one :grin: 