### PR TITLE
onboarding: use `~/.config/mpd`

### DIFF
--- a/src/plattenalbum.py
+++ b/src/plattenalbum.py
@@ -1037,10 +1037,10 @@ class CommandLabel(Gtk.Box):
 class SetupDialog(ConnectDialog):
 	def __init__(self):
 		super().__init__(_("Setup"), GLib.Variant("b", False))
-		box=Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+		box=Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12, width_request=380)
 		box.append(Gtk.Label(label=_("After installing the “Music Player Daemon” (<tt>mpd</tt>) the following two commands"\
 			" will configure and initialize a basic local instance"), use_markup=True, xalign=0, wrap=True))
-		box.append(CommandLabel('cat << EOF > ~/.mpd/mpd.conf\ndb_file\t\t"~/.mpd/database"\nstate_file\t"~/.mpd/state"\n\n'\
+		box.append(CommandLabel('cat << EOF > ~/.config/mpd/mpd.conf\ndb_file\t\t"~/.config/mpd/database"\nstate_file\t"~/.config/mpd/state"\n\n'\
 			'audio_output {\n\ttype\t"pulse"\n\tname\t"Music"\n}\nEOF'))
 		box.append(CommandLabel("systemctl --user enable --now mpd.socket"))
 		self.set_content(box)


### PR DESCRIPTION
As the [mpd docs](https://mpd.readthedocs.io/en/latest/user.html#the-configuration-file) state:

> if you run MPD as a user daemon ... the configuration is read from $XDG_CONFIG_HOME/mpd/mpd.conf (usually ~/.config/mpd/mpd.conf)

Using `~/.config/mpd` is also what [the Arch Wiki  mpd article recommends](https://wiki.archlinux.org/title/Music_Player_Daemon), and a behavior people have come to expect and like. Whether _all_ mpd's files should reside in `XDG_CONFIG_HOME` (instead of  say `~/.mpd`) is a different question, but doing so feels more consistent and makes things like version control easier.

Arguably, I should have used `cat > $XDG_CONFIG_HOME/mpd/mpd.conf ...` instead of ` cat > ~/.config/mpd/mpd.conf ...`. However, I discovered that not setting `XDG_CONFIG_HOME` (default in [Arch, Fedora, and Ubuntu](https://unix.stackexchange.com/questions/726717/how-can-i-find-the-value-of-xdg-config-home-xdg-config-home-xdg-state-home)) is the same as saying that `XDG_CONFIG_HOME` equals `~/.config`. In other words, `$XDG_CONFIG_HOME` is probably empty. People that _do_ set `XDG_CONFIG_HOME` themselves can probably modify plattenalbum's instructions accordingly. 

Oh, and I change the requested width of the GTK.Box that houses the instructions to make  the MPD config commands fit without wrapping.  Not sure if  that's  better done elsewhere. 

----

I know the original configuration example is taken from plattenalbum's github wiki pages, but I can't open PRs to change those. 